### PR TITLE
Show keyboard layout on hyprlock password placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ If you're on a Framework laptop, do this:
 - Create a `.psqlrc` file that prettifies psql output in your terminal.
 - Add a custom screenshot keybind `SUPER + Shift + S` for external
   keyboards without PRINT key.
+- Show the active keyboard layout on the lock screen password placeholder
+  (e.g. `Enter Password (German)` for QWERTZ).
 - Run Dwarf Fortress by typing `dwarffortress` in the terminal.
 - Fix a bug in Omarchy that shows no packages to install in the official menu.
 - Show keyboard clicks with showmethekey. Launch it from the application

--- a/master-install.sh
+++ b/master-install.sh
@@ -18,6 +18,7 @@ bash ./install-precommit.sh
 bash ./update-topbarclock.sh
 bash ./create-psqlrc.sh
 bash ./set-screenshotkeybind.sh
+bash ./update-hyprlock-layout.sh
 bash ./install-show_me_the_key.sh
 bash ./install-pi.sh
 bash ./install-dwarffortress.sh

--- a/update-hyprlock-layout.sh
+++ b/update-hyprlock-layout.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Show the active keyboard layout on the Omarchy lock screen placeholder.
+# Updates ~/.config/hypr/hyprlock.conf
+# Example: "Enter Password (German)" for kb_layout = de (QWERTZ)
+
+set -euo pipefail
+
+CONF="$HOME/.config/hypr/hyprlock.conf"
+BACKUP="${CONF}.bak.$(date +%s)"
+TARGET='placeholder_text = Enter Password ($LAYOUT)'
+
+echo "🔧 Updating hyprlock to show keyboard layout in the password placeholder..."
+
+if [[ ! -f "$CONF" ]]; then
+    echo "Error: $CONF does not exist" >&2
+    exit 1
+fi
+
+if grep -qF "$TARGET" "$CONF"; then
+    echo "Already configured: $TARGET"
+    exit 0
+fi
+
+cp "$CONF" "$BACKUP"
+echo "Backup created: $BACKUP"
+
+# Prefer replacing a plain "Enter Password" placeholder (with optional fingerprint markup)
+if grep -qE '^\s*placeholder_text\s*=' "$CONF"; then
+    sed -i 's|^\(\s*placeholder_text\s*=\s*\).*|\1Enter Password ($LAYOUT)|' "$CONF"
+else
+    echo "Error: no placeholder_text line found in $CONF" >&2
+    cp "$BACKUP" "$CONF"
+    exit 1
+fi
+
+if grep -qF "$TARGET" "$CONF"; then
+    echo "Updated placeholder to show keyboard layout."
+    echo "Takes effect the next time you lock the screen."
+else
+    echo "Error: Failed to update placeholder. Restoring backup." >&2
+    cp "$BACKUP" "$CONF"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `update-hyprlock-layout.sh` to set hyprlock `placeholder_text` to `Enter Password ($LAYOUT)`
- Wire the script into `master-install.sh` and document it in the README
- Helps catch wrong keyboard layouts (e.g. German/QWERTZ) when unlocking — Omarchy/hyprlock still have no show-password toggle

## Test plan
- [ ] Run `bash ./update-hyprlock-layout.sh` on an Omarchy machine with `~/.config/hypr/hyprlock.conf`
- [ ] Confirm placeholder becomes `Enter Password ($LAYOUT)` and a `.bak.*` backup was created
- [ ] Lock the screen (`omarchy system lock`) and verify the active layout name appears (e.g. German)
- [ ] Re-run the script and confirm it is idempotent (`Already configured`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The lock screen password prompt now displays the active keyboard layout, such as “Enter Password (DE)”.
  * Installation and update workflows automatically apply this lock screen enhancement.

* **Documentation**
  * Added instructions describing the active keyboard layout display feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->