### PR TITLE
:sparkles: add json ls to install-lazyextras.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ If you're on a Framework laptop, do this:
 - Install Brave extensions: YouTube blocker, Vimium, Loom screen recorder,
   BlockSite, Proxy SwitchyOmega 3 (ZeroOmega).
   To use Vimium, press `f` on a browser page. For shortcuts, press `?`.
-- Install LazyExtras `lang.markdown` and `lang.python`.
+- Install LazyExtras `lang.json`, `lang.markdown`, and `lang.python`.
+  With `lang.json`, open a `.json` file in Neovim and press `Space c f`
+  (or run `:Format`) to beautify it; selecting lines first formats only
+  the selection.
 - Install pre-commit to enable running `pre-commit install` in a repo with a `.pre-commit-config.yml`.
 - Create a `.psqlrc` file that prettifies psql output in your terminal.
 - Add a custom screenshot keybind `SUPER + Ctrl + S` for external

--- a/install-lazyextras.sh
+++ b/install-lazyextras.sh
@@ -4,6 +4,7 @@ yay -S --noconfirm --needed jq
 
 CONFIG_FILE="$HOME/.config/nvim/lazyvim.json"
 EXTRAS=(
+  "lazyvim.plugins.extras.lang.json"
   "lazyvim.plugins.extras.lang.markdown"
   "lazyvim.plugins.extras.lang.python"
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON language support to the LazyExtras feature list.
  * JSON files and selected lines can now be formatted in Neovim.
  * JSON extras are included automatically in the LazyVim configuration setup.

* **Documentation**
  * Updated the README with instructions for enabling and formatting JSON support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->