### PR TITLE
:recycle: :sparkles: remove loom extension, make brave default

### DIFF
--- a/install-brave.sh
+++ b/install-brave.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 yay -S --noconfirm brave-bin
-echo "✨ Brave Browser installed."
+
+# Set Brave as the default browser (run as user, not sudo)
+xdg-settings set default-web-browser brave-browser.desktop
+xdg-mime default brave-browser.desktop x-scheme-handler/http x-scheme-handler/https text/html application/xhtml+xml
+
+echo "✨ Brave Browser installed and set as default."

--- a/install-braveextensions.sh
+++ b/install-braveextensions.sh
@@ -5,7 +5,6 @@ POLICY_FILE="$POLICY_DIR/managed_extensions.json"
 
 UNHOOK_ID="iniiidjgbmhddeaoblbjoopnmlfnhelf"
 VIMIUM_ID="dbepggeogbaibhgnhhndojpepiihcmeb"
-LOOM_ID="liecbddmkiiihnedobmlmillhodjkdmb"
 BLOCKSITE_ID="eiimnmioipafcokbfikbljfdeojpcgbh"
 SWITCHYOMEGA_ID="pfnededegaaopdmhkdmcofjmoldfiped"
 
@@ -24,11 +23,6 @@ cat <<EOF | sudo tee "$POLICY_FILE" > /dev/null
       "toolbar_pin": "force_pinned"
     },
     "$VIMIUM_ID": {
-      "installation_mode": "force_installed",
-      "update_url": "$UPDATE_URL",
-      "toolbar_pin": "force_pinned"
-    },
-    "$LOOM_ID": {
       "installation_mode": "force_installed",
       "update_url": "$UPDATE_URL",
       "toolbar_pin": "force_pinned"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Brave is now automatically set as the default browser after installation.
  * Installation completion messaging now reflects the default-browser setup.

* **Changes**
  * Removed automatic installation of the Loom browser extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->